### PR TITLE
Removed return object from methods and changed comments to mixed

### DIFF
--- a/src/CampaignsClient.php
+++ b/src/CampaignsClient.php
@@ -57,9 +57,9 @@ class CampaignsClient implements CampaignsClientContract
      * @param int|null $fromIndex values are in number.
      * @param int|null $range     values are in number.
      *
-     * @return object
+     * @return mixed
      */
-    public function getMailingLists(string $sort = 'desc', int $fromIndex = null, int $range = null): object
+    public function getMailingLists(string $sort = 'desc', int $fromIndex = null, int $range = null)
     {
         return $this->postRequest('getmailinglists', [
             'sort' => $sort,
@@ -77,14 +77,14 @@ class CampaignsClient implements CampaignsClientContract
      * @param int|null $fromIndex  values are in number.
      * @param int|null $range      values are in number.
      *
-     * @return object
+     * @return mixed
      */
     public function getListAdvancedDetails(
         string $listKey,
         string $filterType = 'sentcampaigns',
         int $fromIndex = null,
         int $range = null
-    ): object {
+    ){
         return $this->postRequest('getlistadvanceddetails', [
             'listkey' => $listKey,
             'filtertype' => $filterType,
@@ -102,7 +102,7 @@ class CampaignsClient implements CampaignsClientContract
      * @param int|null $fromIndex values are in number.
      * @param int|null $range     values are in number.
      *
-     * @return object
+     * @return mixed
      */
     public function getListSubscribers(
         string $listKey,
@@ -110,7 +110,7 @@ class CampaignsClient implements CampaignsClientContract
         string $sort = 'desc',
         int $fromIndex = null,
         int $range = null
-    ): object {
+    ){
         return $this->postRequest('getlistsubscribers', [
             'listkey' => $listKey,
             'status' => $status,
@@ -141,9 +141,9 @@ class CampaignsClient implements CampaignsClientContract
      * @param string $listKey List Key to send a subscription mail to contacts.
      * @param int    $cvId    You will get cvid from @method getMailingLists().
      *
-     * @return object
+     * @return mixed
      */
-    public function getSegmentDetails(string $listKey, int $cvId): object
+    public function getSegmentDetails(string $listKey, int $cvId)
     {
         return $this->postRequest('getsegmentdetails', [
             'listkey' => $listKey,
@@ -156,9 +156,9 @@ class CampaignsClient implements CampaignsClientContract
      *
      * @param int $cvId You will get cvid from @method getMailingLists().
      *
-     * @return object
+     * @return mixed
      */
-    public function getSegmentContacts(int $cvId): object
+    public function getSegmentContacts(int $cvId)
     {
         return $this->postRequest('getsegmentcontacts', [
             'cvid' => $cvId,
@@ -172,13 +172,13 @@ class CampaignsClient implements CampaignsClientContract
      * @param string $newListName Give list name.
      * @param string $signUpForm  [public/private]
      *
-     * @return object
+     * @return mixed
      */
     public function updateListDetails(
         string $listKey,
         string $newListName,
         string $signUpForm = 'public'
-    ): object {
+    ){
         return $this->postRequest('updatelistdetails', [
             'listkey' => $listKey,
             'newlistname' => $newListName,
@@ -192,9 +192,9 @@ class CampaignsClient implements CampaignsClientContract
      * @param string $listKey        List Key to send a subscription mail to subscribers.
      * @param string $deleteContacts [on/off]
      *
-     * @return object
+     * @return mixed
      */
-    public function deleteMailingList(string $listKey, string $deleteContacts = 'off'): object
+    public function deleteMailingList(string $listKey, string $deleteContacts = 'off')
     {
         return $this->postRequest('deletemailinglist', [
             'listkey' => $listKey,
@@ -208,9 +208,9 @@ class CampaignsClient implements CampaignsClientContract
      * @param string $listKey List Key to send a subscription mail to subscribers
      * @param string $status  [active|unsub|bounce|spam]
      *
-     * @return object
+     * @return mixed
      */
-    public function listSubscribersCount(string $listKey, string $status = 'active'): object
+    public function listSubscribersCount(string $listKey, string $status = 'active')
     {
         return $this->postRequest('listsubscriberscount', [
             'listkey' => $listKey,
@@ -228,13 +228,13 @@ class CampaignsClient implements CampaignsClientContract
      * @param string $contactInfo Subscriber email with other fields. Format of this value depends on the request URL.
      * @param null   $sources     Subscriber source can be added.
      *
-     * @return object
+     * @return mixed
      */
     public function listSubscribe(
         string $listKey,
         string $contactInfo,
         $sources = null
-    ): object {
+    ){
         return $this->postRequest($this->responseFormat . DIRECTORY_SEPARATOR . 'listsubscribe', [
             'listkey' => $listKey,
             'contactinfo' => $contactInfo,
@@ -249,12 +249,12 @@ class CampaignsClient implements CampaignsClientContract
      * @param string $listKey     List Key to send a subscription mail to subscribers
      * @param string $contactInfo Provide email id to be moved to Do-Not-Mail registry.
      *
-     * @return object
+     * @return mixed
      */
     public function listUnsubscribe(
         string $listKey,
         string $contactInfo
-    ): object {
+    ){
         return $this->postRequest($this->responseFormat . DIRECTORY_SEPARATOR . 'listunsubscribe', [
             'listkey' => $listKey,
             'contactinfo' => $contactInfo,
@@ -268,11 +268,11 @@ class CampaignsClient implements CampaignsClientContract
      *
      * @param string $contactInfo Provide email id to be moved to Do-Not-Mail registry.
      *
-     * @return object
+     * @return mixed
      */
     public function contactDoNotMail(
         string $contactInfo
-    ): object {
+    ){
         return $this->postRequest($this->responseFormat . DIRECTORY_SEPARATOR . 'contactdonotmail', [
             'contactinfo' => $contactInfo,
         ]);
@@ -285,12 +285,12 @@ class CampaignsClient implements CampaignsClientContract
      * @param string $listKey  List Key to send a subscription mail to subscribers
      * @param string $emailIds Provide maximum of ten (10) EMAILID's comma (,) separately.
      *
-     * @return object
+     * @return mixed
      */
     public function addListSubscribersInBulk(
         string $listKey,
         string $emailIds
-    ): object {
+    ){
         return $this->postRequest('addlistsubscribersinbulk', [
             'listkey' => $listKey,
             'emailids' => $emailIds,
@@ -307,7 +307,7 @@ class CampaignsClient implements CampaignsClientContract
      * @param string $mode            'newlist'
      * @param string $listDescription Provide a description for your list.
      *
-     * @return object
+     * @return mixed
      */
     public function addListAndContacts(
         string $emailIds,
@@ -315,7 +315,7 @@ class CampaignsClient implements CampaignsClientContract
         string $signUpForm = 'public',
         string $mode = 'newlist',
         string $listDescription = ''
-    ): object {
+    ){
         return $this->postRequest('addlistandcontacts', [
             'emailids' => $emailIds,
             'listname' => $listName,
@@ -334,14 +334,14 @@ class CampaignsClient implements CampaignsClientContract
      * @param int    $fieldLength This lets you to set length of the field. Default value is 20.
      * @param string $type        xml (or) json
      *
-     * @return object
+     * @return mixed
      */
     public function addCustomField(
         string $fieldName,
         string $fieldType,
         int $fieldLength = 20,
         string $type = 'json'
-    ): object {
+    ){
         return $this->postRequest('custom/add', [
             'fieldname' => $fieldName,
             'fieldtype' => $fieldType,
@@ -361,7 +361,7 @@ class CampaignsClient implements CampaignsClientContract
      * @param string $socialValue Give a default value for the tag to be used in email content of social campaigns.
      * @param string $type        xml (or) json
      *
-     * @return object
+     * @return mixed
      */
     public function createMergeTag(
         string $tagType,
@@ -370,7 +370,7 @@ class CampaignsClient implements CampaignsClientContract
         string $mailValue = '',
         string $socialValue = '',
         string $type = 'json'
-    ): object {
+    ){
         return $this->postRequest('merge/create', [
             'tagtype' => $tagType,
             'fieldname' => $fieldName,

--- a/src/CampaignsClientContract.php
+++ b/src/CampaignsClientContract.php
@@ -12,13 +12,13 @@ interface CampaignsClientContract
      * @param int|null $fromIndex values are in number.
      * @param int|null $range     values are in number.
      *
-     * @return object
+     * @return mixed
      */
     public function getMailingLists(
         string $sort = 'desc',
         int $fromIndex = null,
         int $range = null
-    ): object;
+    );
 
     /**
      * Advanced details include all data like subscriber details, stats and complete details about campaigns sent to this mailing list. Using this API, you can get the list's advanced details.
@@ -28,14 +28,14 @@ interface CampaignsClientContract
      * @param int|null $fromIndex  values are in number.
      * @param int|null $range      values are in number.
      *
-     * @return object
+     * @return mixed
      */
     public function getListAdvancedDetails(
         string $listKey,
         string $filterType = 'sentcampaigns',
         int $fromIndex = null,
         int $range = null
-    ): object;
+    );
 
     /**
      *  Fetch the mailing lists.
@@ -46,7 +46,7 @@ interface CampaignsClientContract
      * @param int|null $fromIndex values are in number.
      * @param int|null $range     values are in number.
      *
-     * @return object
+     * @return mixed
      */
     public function getListSubscribers(
         string $listKey,
@@ -54,7 +54,7 @@ interface CampaignsClientContract
         string $sort = 'desc',
         int $fromIndex = null,
         int $range = null
-    ): object;
+    );
 
     /**
      * Fetch subscriber fields to get profile information of the subscribers. Using this API, you can get the list of all subscriber fields.
@@ -73,23 +73,23 @@ interface CampaignsClientContract
      * @param string $listKey List Key to send a subscription mail to contacts.
      * @param int    $cvId    You will get cvid from @method getMailingLists().
      *
-     * @return object
+     * @return mixed
      */
     public function getSegmentDetails(
         string $listKey,
         int $cvId
-    ): object;
+    );
 
     /**
      * Using this API, you can get the segment subscribers along with their relevant details like first name, last name, time when they were added, company and their phone number.
      *
      * @param int $cvId You will get cvid from @method getMailingLists().
      *
-     * @return object
+     * @return mixed
      */
     public function getSegmentContacts(
         int $cvId
-    ): object;
+    );
 
     /**
      * Updating a list can be to rename a list or to associate a signup form to the list. Using this API, you can make changes in mailing lists.
@@ -98,13 +98,13 @@ interface CampaignsClientContract
      * @param string $newListName Give list name.
      * @param string $signUpForm  [public/private]
      *
-     * @return object
+     * @return mixed
      */
     public function updateListDetails(
         string $listKey,
         string $newListName,
         string $signUpForm = 'public'
-    ): object;
+    );
 
     /**
      * Using this API, you can delete a mailing list. All you need to provide is the list key and choose whether to delete all list subscribers from the organization or remove them only from the list.
@@ -112,12 +112,12 @@ interface CampaignsClientContract
      * @param string $listKey        List Key to send a subscription mail to subscribers.
      * @param string $deleteContacts [on/off]
      *
-     * @return object
+     * @return mixed
      */
     public function deleteMailingList(
         string $listKey,
         string $deleteContacts = 'off'
-    ): object;
+    );
 
     /**
      * You don’t have to research on how effective a list has been or how much reach does a particular list measure. Find out using our API Authentication Token to find out the number of subscribers in a list.
@@ -125,12 +125,12 @@ interface CampaignsClientContract
      * @param string $listKey List Key to send a subscription mail to subscribers
      * @param string $status  [active|unsub|bounce|spam]
      *
-     * @return object
+     * @return mixed
      */
     public function listSubscribersCount(
         string $listKey,
         string $status = 'active'
-    ): object;
+    );
 
     /**
      * Users can subscribe to a list without using the signup form or by getting added by another user.
@@ -142,13 +142,13 @@ interface CampaignsClientContract
      * @param string $contactInfo Provide email id to be moved to Do-Not-Mail registry.
      * @param null   $sources     Subscriber source can be added.
      *
-     * @return object
+     * @return mixed
      */
     public function listSubscribe(
         string $listKey,
         string $contactInfo,
         $sources = null
-    ): object;
+    );
 
     /**
      * Disinterested leads in your list? Never mind, all you need to do is unsubscribe them.
@@ -157,12 +157,12 @@ interface CampaignsClientContract
      * @param string $listKey     List Key to send a subscription mail to subscribers
      * @param string $contactInfo Provide email id to be moved to Do-Not-Mail registry.
      *
-     * @return object
+     * @return mixed
      */
     public function listUnsubscribe(
         string $listKey,
         string $contactInfo
-    ): object;
+    );
 
     /**
      * You can move the contact to do-not-mail registry if you do not want to send emails further to that user
@@ -171,11 +171,11 @@ interface CampaignsClientContract
      *
      * @param string $contactInfo Provide email id to be moved to Do-Not-Mail registry.
      *
-     * @return object
+     * @return mixed
      */
     public function contactDoNotMail(
         string $contactInfo
-    ): object;
+    );
 
     /**
      * Did you know that you can also add leads not only to a new list but also existing lists using API?
@@ -184,12 +184,12 @@ interface CampaignsClientContract
      * @param string $listKey  List Key to send a subscription mail to subscribers
      * @param string $emailIds Provide maximum of ten (10) EMAILID's comma (,) separately.
      *
-     * @return object
+     * @return mixed
      */
     public function addListSubscribersInBulk(
         string $listKey,
         string $emailIds
-    ): object;
+    );
 
     /**
      * Using this API, you can add new list and subscribers in the list without having to do this manually in the product UI.
@@ -200,7 +200,7 @@ interface CampaignsClientContract
      * @param string $mode            'newlist'
      * @param string $listDescription Provide a description for your list.
      *
-     * @return object
+     * @return mixed
      */
     public function addListAndContacts(
         string $emailIds,
@@ -208,7 +208,7 @@ interface CampaignsClientContract
         string $signUpForm = 'public',
         string $mode = 'newlist',
         string $listDescription = ''
-    ): object;
+    );
 
     /**
      * Custom fields can be used to feed any type of information, set character limit and use them to save specific data. Using this API, you can create custom fields to store unique information about subscribers.
@@ -218,14 +218,14 @@ interface CampaignsClientContract
      * @param int    $fieldLength This lets you to set length of the field. Default value is 20.
      * @param string $type        xml (or) json
      *
-     * @return object
+     * @return mixed
      */
     public function addCustomField(
         string $fieldName,
         string $fieldType,
         int $fieldLength = 20,
         string $type = 'json'
-    ): object;
+    );
 
 
     /**
@@ -238,7 +238,7 @@ interface CampaignsClientContract
      * @param string $socialValue Give a default value for the tag to be used in email content of social campaigns.
      * @param string $type        xml (or) json
      *
-     * @return object
+     * @return mixed
      */
     public function createMergeTag(
         string $tagType,
@@ -247,5 +247,5 @@ interface CampaignsClientContract
         string $mailValue = '',
         string $socialValue = '',
         string $type = 'json'
-    ): object;
+    );
 }


### PR DESCRIPTION
API would not return an explicit object but an stdClass for every method in the library. postRequest method in CampaignsClient class returns mixed content, so the data type can vary. stdClass return type is another alternative to object, however, the return type from postRequest is mixed.

##########################
Return value of Liliom/Zoho/Campaigns/CampaignsClient::getListSubscribers() must be an instance of Liliom/Zoho/Campaigns/object, instance of stdClass returned
##########################
By the way. Great work! :)
